### PR TITLE
fix: include process.env in user_bash handler

### DIFF
--- a/extensions/index.ts
+++ b/extensions/index.ts
@@ -115,7 +115,7 @@ export default function (pi: ExtensionAPI) {
 					}
 					return localOps.exec(command, execCwd, {
 						...options,
-						env: { ...options.env, ...injectedEnv },
+						env: { ...process.env, ...options.env, ...injectedEnv },
 					});
 				},
 			},


### PR DESCRIPTION
When `options.env` is undefined (the default for `!` commands), `{ ...options.env, ...injectedEnv }` produces an env with only psst secrets — no `PATH`, `HOME`, etc.

This breaks any `!` command that relies on binaries outside the default shell PATH (e.g. `git sync` → `git-sync` at `/opt/homebrew/bin`).

Fix: include `process.env` as the base, matching how the agent bash tool's `spawnHook` already receives the full environment.